### PR TITLE
feat: pi-hole cname records

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 **Plug and play your docker containers into Pi-Hole & Nginx Proxy Manager**
 
 Automatically detect running Docker containers based on labels, add them
-as local DNS records in **Pi-Hole** and create matching proxy hosts in
+as local DNS/CNAME records in **Pi-Hole** and create matching proxy hosts in
 **Nginx Proxy Manager**.
 
 ## Key Features
 
 - Automatic Docker container detection.
-- Local DNS record creation in Pi-hole.
+- Local DNS/CNAME record creation in Pi-hole.
 - Nginx Proxy Manager host creation.
 - Support for Docker socket proxy.
 
@@ -28,14 +28,14 @@ PlugNPiN discovers services by scanning for Docker containers that have the foll
 
 The application operates in two complementary modes to keep your services synchronized:
 
-1.  **Real-Time Event Listening**: The application actively listens for Docker container events. When a container with the required labels is **started**, **stopped**, or **killed**, the tool immediately adds or removes the corresponding DNS and proxy host entries. This ensures that your services are updated in real-time as containers change state.
+1. **Real-Time Event Listening**: The application actively listens for Docker container events. When a container with the required labels is **started**, **stopped**, or **killed**, the tool immediately adds or removes the corresponding DNS and proxy host entries. This ensures that your services are updated in real-time as containers change state.
 
-2.  **Periodic Synchronization**: In addition to real-time events, the tool performs a full synchronization at a regular interval, defined by the `RUN_INTERVAL` environment variable. During this periodic run, it scans all running containers and ensures that their DNS and proxy configurations are correct. This acts as a self-healing mechanism, correcting any entries that might have been missed or become inconsistent.
+2. **Periodic Synchronization**: In addition to real-time events, the tool performs a full synchronization at a regular interval, defined by the `RUN_INTERVAL` environment variable. During this periodic run, it scans all running containers and ensures that their DNS and proxy configurations are correct. This acts as a self-healing mechanism, correcting any entries that might have been missed or become inconsistent.
 
 When a container is processed in either mode, PlugNPiN will:
 
-1.  Create a DNS record pointing the specified `url` to the `ip` address on **Pi-Hole**.
-2.  Create a proxy host to route traffic from the `url` to the container's `ip` and `port` on **Nginx Proxy Manager**.
+1. Create a DNS record pointing the specified `url` to the `ip` address on **Pi-Hole** (or a CNAME record pointing to a configurable target domain).
+2. Create a proxy host to route traffic from the `url` to the container's `ip` and `port` on **Nginx Proxy Manager**.
 
 ## Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 **Plug and play your docker containers into Pi-Hole & Nginx Proxy Manager**
 
 Automatically detect running Docker containers based on labels, add them
-as local DNS records in **Pi-Hole** and create matching proxy hosts in
+as local DNS/[CNAME](#targetDomainLabel) records in **Pi-Hole** and create matching proxy hosts in
 **Nginx Proxy Manager**.
 
 ## How It Works
@@ -25,8 +25,13 @@ The application operates in two complementary modes to keep your services synchr
 
 When a container is processed in either mode, PlugNPiN will:
 
-1. Create a DNS record pointing the specified `url` to the `ip` address on **Pi-Hole**.
+1. Create a DNS record pointing the specified `url` to the `ip` address on **Pi-Hole** (or a [CNAME record](#targetDomainLabel) pointing to a configurable target domain).
 2. Create a proxy host to route traffic from the `url` to the container's `ip` and `port` on **Nginx Proxy Manager**.
+
+### CNAME Records
+
+It is possible to force PlugNPiN to create CNAME records instead of local DNS records ("A record") in Pi-Hole by setting the `plugNPiN.piholeOptions.targetDomain` label.
+See [Per Container Configuration ➔ Pi-Hole](#targetDomainLabel).
 
 ## Configuration
 
@@ -39,8 +44,8 @@ When a container is processed in either mode, PlugNPiN will:
 | `NGINX_PROXY_MANAGER_HOST` | The URL of your Nginx Proxy Manager instance. |
 | `NGINX_PROXY_MANAGER_USERNAME` | Your Nginx Proxy Manager username. |
 | `NGINX_PROXY_MANAGER_PASSWORD` | Your Nginx Proxy Manager password. <br> **Important:** It is recommended to create a new non-admin user with only the "Proxy Hosts - Manage" permission. |
-| `PIHOLE_HOST` | The URL of your Pi-hole instance. |
-| `PIHOLE_PASSWORD` | Your Pi-hole password. <br> **Important:** It is recommended to create an 'application password' rather than using your actual admin password. |
+| `PIHOLE_HOST` | The URL of your Pi-Hole instance. |
+| `PIHOLE_PASSWORD` | Your Pi-Hole password. <br> **Important:** It is recommended to create an 'application password' rather than using your actual admin password. |
 
 #### Optional
 
@@ -54,7 +59,7 @@ When a container is processed in either mode, PlugNPiN will:
 
 | Flag {: style="width:35%" } | Description |
 |---|---|
-| `--dry-run`, `-d` | Simulates the process of adding DNS records and proxy hosts without making any actual changes to Pi-hole or Nginx Proxy Manager. |
+| `--dry-run`, `-d` | Simulates the process of adding DNS/CNAME records and proxy hosts without making any actual changes to Pi-Hole or Nginx Proxy Manager. |
 
 ### Per Container Configuration
 
@@ -73,6 +78,12 @@ Use the following labels to configure Nginx Proxy Manager entries
 | `plugNPiN.npmOptions.hstsSubdomains` | Enable HSTS Subdomains | `false` |
 | `plugNPiN.npmOptions.scheme` | The scheme used to forward traffic to the container. Can be `http` or `https` | `http` |
 | `plugNPiN.npmOptions.websocketsSupport` | Enables or disables the "Allow Websocket Upgrade" option on the proxy host. Set to `true` or `false` | `false` |
+
+#### Pi-Hole
+
+| Label {: style="width:35%"} | Description | Default {: style="width:10%"} |
+|---|---|---|
+| <a name="targetDomainLabel"></a>`plugNPiN.piholeOptions.targetDomain` | If provided, a CNAME record will be created **instead** of a DNS record |  |
 
 ## Usage
 

--- a/pkg/clients/pihole/pihole.go
+++ b/pkg/clients/pihole/pihole.go
@@ -46,22 +46,22 @@ func (p *Client) Login(password string) error {
 	return nil
 }
 
-func rawDNSHostRawEntryToEntry(rawDNSHostEntry string) (DomainName, IP, error) {
-	splitRawDNSHostEntry := strings.Split(rawDNSHostEntry, " ")
-	if len(splitRawDNSHostEntry) == 2 {
-		ip := IP(splitRawDNSHostEntry[0])
-		domain := DomainName(splitRawDNSHostEntry[1])
+func rawDnsRecordToRecord(rawDnsRecord string) (DomainName, IP, error) {
+	splitRawDnsRecord := strings.Split(rawDnsRecord, " ")
+	if len(splitRawDnsRecord) == 2 {
+		ip := IP(splitRawDnsRecord[0])
+		domain := DomainName(splitRawDnsRecord[1])
 		return domain, ip, nil
 	} else {
-		return "", "", fmt.Errorf("got bad raw dns host entry from pihole: %v", rawDNSHostEntry)
+		return "", "", fmt.Errorf("got bad raw dns host entry from pihole: %v", rawDnsRecord)
 	}
 }
 
-func dnsHostEntryToRawEntry(domain DomainName, ip IP) string {
+func dnsRecordToRaw(domain DomainName, ip IP) string {
 	return fmt.Sprintf("%v %v", ip, domain)
 }
 
-func (p *Client) getDNSHosts() (DNSHostEntries, error) {
+func (p *Client) getDnsRecords() (DnsRecords, error) {
 	if p.sid == "" {
 		// TODO:
 		log.Fatal("no SID")
@@ -74,38 +74,38 @@ func (p *Client) getDNSHosts() (DNSHostEntries, error) {
 	var resp configResponse
 	json.Unmarshal([]byte(configResponseString), &resp)
 
-	dnsHostEntries := DNSHostEntries{}
-	for _, rawDNSHostEntry := range resp.Config.DNS.Hosts {
-		domain, ip, err := rawDNSHostRawEntryToEntry(rawDNSHostEntry)
+	dnsRecords := DnsRecords{}
+	for _, rawDnsRecords := range resp.Config.DNS.Hosts {
+		domain, ip, err := rawDnsRecordToRecord(rawDnsRecords)
 		if err != nil {
 			return nil, err
 		}
-		dnsHostEntries[domain] = ip
+		dnsRecords[domain] = ip
 	}
-	return dnsHostEntries, nil
+	return dnsRecords, nil
 }
 
-func (p *Client) AddDNSHostEntry(domain, ip string) error {
-	existingEntries, err := p.getDNSHosts()
+func (p *Client) AddDnsRecord(domain, ip string) error {
+	existingRecords, err := p.getDnsRecords()
 	if err != nil {
 		return err
 	}
 	d := DomainName(domain)
-	_, exists := existingEntries[d]
+	_, exists := existingRecords[d]
 
 	if exists {
 		return nil
 	}
 
-	existingEntries[d] = IP(ip)
+	existingRecords[d] = IP(ip)
 
-	rawEntriesSlice := []string{}
-	for domain, ip := range existingEntries {
-		rawEntriesSlice = append(rawEntriesSlice, dnsHostEntryToRawEntry(domain, ip))
+	rawRecordsSlice := []string{}
+	for domain, ip := range existingRecords {
+		rawRecordsSlice = append(rawRecordsSlice, dnsRecordToRaw(domain, ip))
 	}
 
-	payload := updateDNSHostsEntriesPayload{}
-	payload.Config.DNS.Hosts = rawEntriesSlice
+	payload := updateDnsRecordsPayload{}
+	payload.Config.DNS.Hosts = rawRecordsSlice
 
 	payloadString, err := json.Marshal(payload)
 	if err != nil {
@@ -130,27 +130,156 @@ func (p *Client) AddDNSHostEntry(domain, ip string) error {
 	return nil
 }
 
-func (p *Client) DeleteDNSHostEntry(domain, ip string) error {
-	existingEntries, err := p.getDNSHosts()
+func (p *Client) DeleteDnsRecord(domain, ip string) error {
+	existingRecords, err := p.getDnsRecords()
 	if err != nil {
 		return err
 	}
 	d := DomainName(domain)
-	_, exists := existingEntries[d]
+	_, exists := existingRecords[d]
 
 	if !exists {
 		return nil
 	}
 
-	delete(existingEntries, d)
+	delete(existingRecords, d)
 
-	rawEntriesSlice := []string{}
-	for domain, ip := range existingEntries {
-		rawEntriesSlice = append(rawEntriesSlice, dnsHostEntryToRawEntry(domain, ip))
+	rawRecordsSlice := []string{}
+	for domain, ip := range existingRecords {
+		rawRecordsSlice = append(rawRecordsSlice, dnsRecordToRaw(domain, ip))
 	}
 
-	payload := updateDNSHostsEntriesPayload{}
-	payload.Config.DNS.Hosts = rawEntriesSlice
+	payload := updateDnsRecordsPayload{}
+	payload.Config.DNS.Hosts = rawRecordsSlice
+
+	payloadString, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	if p.sid == "" {
+		// TODO:
+		log.Fatal("no SID")
+	}
+	headers["X-FTL-SID"] = p.sid
+	resp, statusCode, err := clients.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
+	if err != nil {
+		return err
+	}
+	if statusCode >= 400 {
+		var errorResponse ErrorResponse
+		json.Unmarshal([]byte(resp), &errorResponse)
+		return fmt.Errorf("%v. %v", errorResponse.Error.Message, errorResponse.Error.Hint)
+	}
+
+	return nil
+}
+
+func rawCNameRecordToRecord(rawCNameRecord string) (DomainName, Target, error) {
+	splitRawCNameRecord := strings.Split(rawCNameRecord, ",")
+	if len(splitRawCNameRecord) == 2 {
+		domain := DomainName(splitRawCNameRecord[0])
+		target := Target(splitRawCNameRecord[1])
+		return domain, target, nil
+	} else {
+		return "", "", fmt.Errorf("got bad raw CNAME record from pihole: %v", rawCNameRecord)
+	}
+}
+
+func cNameRecordToRaw(domain DomainName, target Target) string {
+	return fmt.Sprintf("%v,%v", domain, target)
+}
+
+func (p *Client) getCNameRecords() (CNameRecords, error) {
+	if p.sid == "" {
+		// TODO:
+		log.Fatal("no SID")
+	}
+	headers["X-FTL-SID"] = p.sid
+	configResponseString, _, err := clients.Get(&p.Client, p.baseURL+"/config", headers)
+	if err != nil {
+		return nil, err
+	}
+	var resp configResponse
+	json.Unmarshal([]byte(configResponseString), &resp)
+
+	cNameRecords := CNameRecords{}
+	for _, rawCNameRecord := range resp.Config.DNS.CnameRecords {
+		domain, target, err := rawCNameRecordToRecord(rawCNameRecord.(string))
+		if err != nil {
+			return nil, err
+		}
+		cNameRecords[domain] = target
+	}
+	return cNameRecords, nil
+}
+
+func (p *Client) AddCNameRecord(domain, target string) error {
+	existingRecords, err := p.getCNameRecords()
+	if err != nil {
+		return err
+	}
+	d := DomainName(domain)
+	_, exists := existingRecords[d]
+
+	if exists {
+		return nil
+	}
+
+	existingRecords[d] = Target(target)
+
+	rawRecordsSlice := []string{}
+	for domain, target := range existingRecords {
+		rawRecordsSlice = append(rawRecordsSlice, cNameRecordToRaw(domain, target))
+	}
+
+	payload := updateCNameRecordsPayload{}
+	payload.Config.DNS.CnameRecords = rawRecordsSlice
+
+	payloadString, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	if p.sid == "" {
+		// TODO:
+		log.Fatal("no SID")
+	}
+	headers["X-FTL-SID"] = p.sid
+	resp, statusCode, err := clients.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
+	if err != nil {
+		return err
+	}
+	if statusCode >= 400 {
+		var errorResponse ErrorResponse
+		json.Unmarshal([]byte(resp), &errorResponse)
+		return fmt.Errorf("%v. %v", errorResponse.Error.Message, errorResponse.Error.Hint)
+	}
+
+	return nil
+}
+
+func (p *Client) DeleteCNameRecord(domain, target string) error {
+	existingRecords, err := p.getCNameRecords()
+	if err != nil {
+		return err
+	}
+	d := DomainName(domain)
+	_, exists := existingRecords[d]
+
+	if !exists {
+		return nil
+	}
+
+	delete(existingRecords, d)
+
+	rawRecordsSlice := []string{}
+	for domain, target := range existingRecords {
+		rawRecordsSlice = append(rawRecordsSlice, cNameRecordToRaw(domain, target))
+	}
+
+	payload := updateCNameRecordsPayload{}
+	payload.Config.DNS.CnameRecords = rawRecordsSlice
 
 	payloadString, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/clients/pihole/pihole_test.go
+++ b/pkg/clients/pihole/pihole_test.go
@@ -58,7 +58,7 @@ func TestLogin(t *testing.T) {
 	})
 }
 
-func TestAddDNSHostEntry(t *testing.T) {
+func TestAddDnsRecord(t *testing.T) {
 	t.Run("successful add", func(t *testing.T) {
 		// This handler needs to handle two requests in sequence
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -66,22 +66,22 @@ func TestAddDNSHostEntry(t *testing.T) {
 			assert.Equal(t, "test-sid", r.Header.Get("X-FTL-SID"))
 
 			if r.Method == http.MethodGet {
-				// 1. First, the function gets the existing hosts.
+				// 1. First, the function gets the existing records.
 				w.WriteHeader(http.StatusOK)
-				// Respond with one existing host.
+				// Respond with one existing record.
 				fmt.Fprint(w, `{"config": {"dns": {"hosts": ["1.1.1.1 one.com"]}}}`)
 				return
 			}
 
 			if r.Method == http.MethodPatch {
 				// 2. Second, the function patches the new list.
-				var payload updateDNSHostsEntriesPayload
+				var payload updateDnsRecordsPayload
 				err := json.NewDecoder(r.Body).Decode(&payload)
 				assert.NoError(t, err)
 
-				// Assert that the new payload contains both the old and the new entry.
-				expectedHosts := []string{"1.1.1.1 one.com", "1.2.3.4 test.com"}
-				assert.ElementsMatch(t, expectedHosts, payload.Config.DNS.Hosts)
+				// Assert that the new payload contains both the old and the new record.
+				expectedRecords := []string{"1.1.1.1 one.com", "1.2.3.4 test.com"}
+				assert.ElementsMatch(t, expectedRecords, payload.Config.DNS.Hosts)
 
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, `{"success": true}`)
@@ -98,12 +98,12 @@ func TestAddDNSHostEntry(t *testing.T) {
 		// Manually set the session ID that the login step would have provided
 		client.sid = "test-sid"
 
-		err := client.AddDNSHostEntry("test.com", "1.2.3.4")
+		err := client.AddDnsRecord("test.com", "1.2.3.4")
 		assert.NoError(t, err)
 	})
 }
 
-func TestDeleteDNSHostEntry(t *testing.T) {
+func TestDeleteDnsRecord(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
 		patchCalled := false
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -112,20 +112,20 @@ func TestDeleteDNSHostEntry(t *testing.T) {
 
 			if r.Method == http.MethodGet {
 				w.WriteHeader(http.StatusOK)
-				// Respond with two existing hosts, one of which we will delete.
+				// Respond with two existing records, one of which we will delete.
 				fmt.Fprint(w, `{"config": {"dns": {"hosts": ["1.1.1.1 one.com", "2.2.2.2 two.com"]}}}`)
 				return
 			}
 
 			if r.Method == http.MethodPatch {
 				patchCalled = true
-				var payload updateDNSHostsEntriesPayload
+				var payload updateDnsRecordsPayload
 				err := json.NewDecoder(r.Body).Decode(&payload)
 				assert.NoError(t, err)
 
-				// Assert that the new payload contains only the remaining entry.
-				expectedHosts := []string{"1.1.1.1 one.com"}
-				assert.ElementsMatch(t, expectedHosts, payload.Config.DNS.Hosts)
+				// Assert that the new payload contains only the remaining record.
+				expectedRecords := []string{"1.1.1.1 one.com"}
+				assert.ElementsMatch(t, expectedRecords, payload.Config.DNS.Hosts)
 
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, `{"success": true}`)
@@ -138,12 +138,12 @@ func TestDeleteDNSHostEntry(t *testing.T) {
 		defer server.Close()
 		client.sid = "test-sid"
 
-		err := client.DeleteDNSHostEntry("two.com", "2.2.2.2")
+		err := client.DeleteDnsRecord("two.com", "2.2.2.2")
 		assert.NoError(t, err)
 		assert.True(t, patchCalled, "The PATCH endpoint was not called")
 	})
 
-	t.Run("no action if host does not exist", func(t *testing.T) {
+	t.Run("no action if record does not exist", func(t *testing.T) {
 		patchCalled := false
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "/api/config", r.URL.Path)
@@ -161,51 +161,201 @@ func TestDeleteDNSHostEntry(t *testing.T) {
 		defer server.Close()
 		client.sid = "test-sid"
 
-		err := client.DeleteDNSHostEntry("non-existent.com", "3.3.3.3")
+		err := client.DeleteDnsRecord("non-existent.com", "3.3.3.3")
 		assert.NoError(t, err)
 		assert.False(t, patchCalled, "The PATCH endpoint was called unexpectedly")
 	})
 }
 
-func TestRawDNSHostRawEntryToEntry(t *testing.T) {
+func TestRawDnsRecordToRecord(t *testing.T) {
 	testCases := []struct {
-		name        string
-		input       string
-		expectedDom DomainName
-		expectedIP  IP
-		expectErr   bool
+		name               string
+		input              string
+		expectedDomainName DomainName
+		expectedIP         IP
+		expectErr          bool
 	}{
 		{
-			name:        "happy path",
-			input:       "1.2.3.4 test.com",
-			expectedDom: "test.com",
-			expectedIP:  "1.2.3.4",
-			expectErr:   false,
+			name:               "happy path",
+			input:              "1.2.3.4 test.com",
+			expectedDomainName: "test.com",
+			expectedIP:         "1.2.3.4",
+			expectErr:          false,
 		},
 		{
-			name:        "malformed entry",
-			input:       "baddata",
-			expectedDom: "",
-			expectedIP:  "",
-			expectErr:   true,
+			name:               "malformed record",
+			input:              "baddata",
+			expectedDomainName: "",
+			expectedIP:         "",
+			expectErr:          true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			dom, ip, err := rawDNSHostRawEntryToEntry(tc.input)
-			assert.Equal(t, tc.expectedDom, dom)
+			domainName, ip, err := rawDnsRecordToRecord(tc.input)
+			assert.Equal(t, tc.expectedDomainName, domainName)
 			assert.Equal(t, tc.expectedIP, ip)
 			assert.Equal(t, tc.expectErr, err != nil)
 		})
 	}
 }
 
-func TestDnsHostEntryToRawEntry(t *testing.T) {
+func TestDnsRecordToRaw(t *testing.T) {
 	dom := DomainName("test.com")
 	ip := IP("1.2.3.4")
 	expected := "1.2.3.4 test.com"
-	actual := dnsHostEntryToRawEntry(dom, ip)
+	actual := dnsRecordToRaw(dom, ip)
 	assert.Equal(t, expected, actual)
 }
 
+func TestAddCNameRecord(t *testing.T) {
+	t.Run("successful add", func(t *testing.T) {
+		// This handler needs to handle two requests in sequence
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/config", r.URL.Path)
+			assert.Equal(t, "test-sid", r.Header.Get("X-FTL-SID"))
+
+			if r.Method == http.MethodGet {
+				// 1. First, the function gets the existing cname records.
+				w.WriteHeader(http.StatusOK)
+				// Respond with one existing cname record.
+				fmt.Fprint(w, `{"config": {"dns": {"cnameRecords": ["one.com,one.two.com"]}}}`)
+				return
+			}
+
+			if r.Method == http.MethodPatch {
+				// 2. Second, the function patches the new list.
+				var payload updateCNameRecordsPayload
+				err := json.NewDecoder(r.Body).Decode(&payload)
+				assert.NoError(t, err)
+
+				// Assert that the new payload contains both the old and the new record.
+				expectedCNames := []string{"one.com,one.two.com", "test.com,test.two.com"}
+				assert.ElementsMatch(t, expectedCNames, payload.Config.DNS.CnameRecords)
+
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"success": true}`)
+				return
+			}
+
+			// Fail test if an unexpected request is made
+			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
+		})
+
+		client, server := setupTestServer(handler)
+		defer server.Close()
+
+		// Manually set the session ID that the login step would have provided
+		client.sid = "test-sid"
+
+		err := client.AddCNameRecord("test.com", "test.two.com")
+		assert.NoError(t, err)
+	})
+}
+
+func TestDeleteCNameRecord(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		patchCalled := false
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/config", r.URL.Path)
+			assert.Equal(t, "test-sid", r.Header.Get("X-FTL-SID"))
+
+			if r.Method == http.MethodGet {
+				w.WriteHeader(http.StatusOK)
+				// Respond with two existing cname records, one of which we will delete.
+				fmt.Fprint(w, `{"config": {"dns": {"cnameRecords": ["one.com,one.two.com", "two.com,two.two.com"]}}}`)
+				return
+			}
+
+			if r.Method == http.MethodPatch {
+				patchCalled = true
+				var payload updateCNameRecordsPayload
+				err := json.NewDecoder(r.Body).Decode(&payload)
+				assert.NoError(t, err)
+
+				// Assert that the new payload contains only the remaining record.
+				expectedCNames := []string{"one.com,one.two.com"}
+				assert.ElementsMatch(t, expectedCNames, payload.Config.DNS.CnameRecords)
+
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, `{"success": true}`)
+				return
+			}
+			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
+		})
+
+		client, server := setupTestServer(handler)
+		defer server.Close()
+		client.sid = "test-sid"
+
+		err := client.DeleteCNameRecord("two.com", "two.two.com")
+		assert.NoError(t, err)
+		assert.True(t, patchCalled, "The PATCH endpoint was not called")
+	})
+
+	t.Run("no action if cname does not exist", func(t *testing.T) {
+		patchCalled := false
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/config", r.URL.Path)
+			assert.Equal(t, http.MethodGet, r.Method)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"config": {"dns": {"cname": ["one.com,one.two.com"]}}}`)
+
+			if r.Method == http.MethodPatch {
+				patchCalled = true
+			}
+		})
+
+		client, server := setupTestServer(handler)
+		defer server.Close()
+		client.sid = "test-sid"
+
+		err := client.DeleteCNameRecord("non-existent.com", "non-existent.two.com")
+		assert.NoError(t, err)
+		assert.False(t, patchCalled, "The PATCH endpoint was called unexpectedly")
+	})
+}
+
+func TestRawCNameRecordToRecord(t *testing.T) {
+	testCases := []struct {
+		name               string
+		input              string
+		expectedDomainName DomainName
+		expectedTarget     Target
+		expectErr          bool
+	}{
+		{
+			name:               "happy path",
+			input:              "test.com,target.com",
+			expectedDomainName: "test.com",
+			expectedTarget:     "target.com",
+			expectErr:          false,
+		},
+		{
+			name:               "malformed record",
+			input:              "baddata",
+			expectedDomainName: "",
+			expectedTarget:     "",
+			expectErr:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			domainName, target, err := rawCNameRecordToRecord(tc.input)
+			assert.Equal(t, tc.expectedDomainName, domainName)
+			assert.Equal(t, tc.expectedTarget, target)
+			assert.Equal(t, tc.expectErr, err != nil)
+		})
+	}
+}
+
+func TestCNameRecordToRaw(t *testing.T) {
+	dom := DomainName("test.com")
+	target := Target("target.com")
+	expected := "test.com,target.com"
+	actual := cNameRecordToRaw(dom, target)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/clients/pihole/types.go
+++ b/pkg/clients/pihole/types.go
@@ -15,29 +15,29 @@ type loginResponse struct {
 type configResponse struct {
 	Config struct {
 		DNS struct {
-			Upstreams           []string      `json:"upstreams"`
-			CNAMEdeepInspect    bool          `json:"CNAMEdeepInspect"`
-			BlockESNI           bool          `json:"blockESNI"`
-			EDNS0ECS            bool          `json:"EDNS0ECS"`
-			IgnoreLocalhost     bool          `json:"ignoreLocalhost"`
-			ShowDNSSEC          bool          `json:"showDNSSEC"`
-			AnalyzeOnlyAandAAAA bool          `json:"analyzeOnlyAandAAAA"`
-			PiholePTR           string        `json:"piholePTR"`
-			ReplyWhenBusy       string        `json:"replyWhenBusy"`
-			BlockTTL            int           `json:"blockTTL"`
-			Hosts               []string      `json:"hosts"`
-			DomainNeeded        bool          `json:"domainNeeded"`
-			ExpandHosts         bool          `json:"expandHosts"`
-			Domain              string        `json:"domain"`
-			BogusPriv           bool          `json:"bogusPriv"`
-			Dnssec              bool          `json:"dnssec"`
-			Interface           string        `json:"interface"`
-			HostRecord          string        `json:"hostRecord"`
-			ListeningMode       string        `json:"listeningMode"`
-			QueryLogging        bool          `json:"queryLogging"`
-			CnameRecords        []interface{} `json:"cnameRecords"`
-			Port                int           `json:"port"`
-			RevServers          []interface{} `json:"revServers"`
+			Upstreams           []string `json:"upstreams"`
+			CNAMEdeepInspect    bool     `json:"CNAMEdeepInspect"`
+			BlockESNI           bool     `json:"blockESNI"`
+			EDNS0ECS            bool     `json:"EDNS0ECS"`
+			IgnoreLocalhost     bool     `json:"ignoreLocalhost"`
+			ShowDNSSEC          bool     `json:"showDNSSEC"`
+			AnalyzeOnlyAandAAAA bool     `json:"analyzeOnlyAandAAAA"`
+			PiholePTR           string   `json:"piholePTR"`
+			ReplyWhenBusy       string   `json:"replyWhenBusy"`
+			BlockTTL            int      `json:"blockTTL"`
+			Hosts               []string `json:"hosts"`
+			DomainNeeded        bool     `json:"domainNeeded"`
+			ExpandHosts         bool     `json:"expandHosts"`
+			Domain              string   `json:"domain"`
+			BogusPriv           bool     `json:"bogusPriv"`
+			Dnssec              bool     `json:"dnssec"`
+			Interface           string   `json:"interface"`
+			HostRecord          string   `json:"hostRecord"`
+			ListeningMode       string   `json:"listeningMode"`
+			QueryLogging        bool     `json:"queryLogging"`
+			CnameRecords        []any    `json:"cnameRecords"`
+			Port                int      `json:"port"`
+			RevServers          []any    `json:"revServers"`
 			Cache               struct {
 				Size               int `json:"size"`
 				Optimizer          int `json:"optimizer"`
@@ -73,18 +73,18 @@ type configResponse struct {
 			} `json:"rateLimit"`
 		} `json:"dns"`
 		Dhcp struct {
-			Active               bool          `json:"active"`
-			Start                string        `json:"start"`
-			End                  string        `json:"end"`
-			Router               string        `json:"router"`
-			Netmask              string        `json:"netmask"`
-			LeaseTime            string        `json:"leaseTime"`
-			Ipv6                 bool          `json:"ipv6"`
-			RapidCommit          bool          `json:"rapidCommit"`
-			MultiDNS             bool          `json:"multiDNS"`
-			Logging              bool          `json:"logging"`
-			IgnoreUnknownClients bool          `json:"ignoreUnknownClients"`
-			Hosts                []interface{} `json:"hosts"`
+			Active               bool   `json:"active"`
+			Start                string `json:"start"`
+			End                  string `json:"end"`
+			Router               string `json:"router"`
+			Netmask              string `json:"netmask"`
+			LeaseTime            string `json:"leaseTime"`
+			Ipv6                 bool   `json:"ipv6"`
+			RapidCommit          bool   `json:"rapidCommit"`
+			MultiDNS             bool   `json:"multiDNS"`
+			Logging              bool   `json:"logging"`
+			IgnoreUnknownClients bool   `json:"ignoreUnknownClients"`
+			Hosts                []any  `json:"hosts"`
 		} `json:"dhcp"`
 		Ntp struct {
 			Ipv4 struct {
@@ -147,20 +147,20 @@ type configResponse struct {
 				Theme string `json:"theme"`
 			} `json:"interface"`
 			API struct {
-				MaxSessions            int           `json:"max_sessions"`
-				PrettyJSON             bool          `json:"prettyJSON"`
-				Pwhash                 string        `json:"pwhash"`
-				Password               string        `json:"password"`
-				TotpSecret             string        `json:"totp_secret"`
-				AppPwhash              string        `json:"app_pwhash"`
-				AppSudo                bool          `json:"app_sudo"`
-				CliPw                  bool          `json:"cli_pw"`
-				ExcludeClients         []interface{} `json:"excludeClients"`
-				ExcludeDomains         []interface{} `json:"excludeDomains"`
-				MaxHistory             int           `json:"maxHistory"`
-				MaxClients             int           `json:"maxClients"`
-				ClientHistoryGlobalMax bool          `json:"client_history_global_max"`
-				AllowDestructive       bool          `json:"allow_destructive"`
+				MaxSessions            int    `json:"max_sessions"`
+				PrettyJSON             bool   `json:"prettyJSON"`
+				Pwhash                 string `json:"pwhash"`
+				Password               string `json:"password"`
+				TotpSecret             string `json:"totp_secret"`
+				AppPwhash              string `json:"app_pwhash"`
+				AppSudo                bool   `json:"app_sudo"`
+				CliPw                  bool   `json:"cli_pw"`
+				ExcludeClients         []any  `json:"excludeClients"`
+				ExcludeDomains         []any  `json:"excludeDomains"`
+				MaxHistory             int    `json:"maxHistory"`
+				MaxClients             int    `json:"maxClients"`
+				ClientHistoryGlobalMax bool   `json:"client_history_global_max"`
+				AllowDestructive       bool   `json:"allow_destructive"`
 				Temp                   struct {
 					Limit int    `json:"limit"`
 					Unit  string `json:"unit"`
@@ -181,14 +181,14 @@ type configResponse struct {
 			} `json:"log"`
 		} `json:"files"`
 		Misc struct {
-			Privacylevel int           `json:"privacylevel"`
-			DelayStartup int           `json:"delay_startup"`
-			Nice         int           `json:"nice"`
-			Addr2Line    bool          `json:"addr2line"`
-			EtcDnsmasqD  bool          `json:"etc_dnsmasq_d"`
-			DnsmasqLines []interface{} `json:"dnsmasq_lines"`
-			ExtraLogging bool          `json:"extraLogging"`
-			ReadOnly     bool          `json:"readOnly"`
+			Privacylevel int   `json:"privacylevel"`
+			DelayStartup int   `json:"delay_startup"`
+			Nice         int   `json:"nice"`
+			Addr2Line    bool  `json:"addr2line"`
+			EtcDnsmasqD  bool  `json:"etc_dnsmasq_d"`
+			DnsmasqLines []any `json:"dnsmasq_lines"`
+			ExtraLogging bool  `json:"extraLogging"`
+			ReadOnly     bool  `json:"readOnly"`
 			Check        struct {
 				Load  bool `json:"load"`
 				Shmem int  `json:"shmem"`
@@ -240,7 +240,7 @@ type ErrorResponse struct {
 	Took float64 `json:"took"`
 }
 
-type updateDNSHostsEntriesPayload struct {
+type updateDnsRecordsPayload struct {
 	Config struct {
 		DNS struct {
 			Hosts []string `json:"hosts"`
@@ -248,8 +248,22 @@ type updateDNSHostsEntriesPayload struct {
 	} `json:"config"`
 }
 
+type updateCNameRecordsPayload struct {
+	Config struct {
+		DNS struct {
+			CnameRecords []string `json:"cnameRecords"`
+		}
+	}
+}
+
+type PiHoleOptions struct {
+	TargetDomain string
+}
+
 type (
-	DomainName     string
-	IP             string
-	DNSHostEntries map[DomainName]IP
+	CNameRecords map[DomainName]Target
+	DnsRecords   map[DomainName]IP
+	DomainName   string
+	IP           string
+	Target       string
 )


### PR DESCRIPTION
a CNAME record can be created in Pi-Hole (instead of the default DNS record) by setting the `plugNPiN.piholeOptions.targetDomain` label on a container. 

If set, the the value of the `plugNPiN.url` label will be used as the "domain" part of the CNAME record and the value of the `plugNPiN.piholeOptions.targetDomain` label will be used as the "target" part of the CNAME record.

closes #12