### PR TITLE
feat: createOnHealthy container label

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,11 +31,17 @@
 
 Use the following labels on your containers to enable specific features
 
+### General Options
+
+| Label {: style="width:45%"} | Description | Default {: style="width:10%"} | Notes |
+|---|---|---|---|
+| `plugNPiN.options.createOnHealthy` | If set to `true`, PlugNPiN will wait for the container to become **healthy** before creating entries | `false` | **This option requires the container to have a [Docker Healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck){: target="_blank" } defined. If no healthcheck is found, an error will be logged and no entries will be created** |
+
 ### AdGuard Home
 
-| Label {: style="width:45%"} | Description | Default {: style="width:10%"} |
-|---|---|---|
-| `plugNPiN.adguardHomeOptions.targetDomain` | If provided, a CNAME DNS Rewrite will be created  |  |
+| Label {: style="width:45%"} | Description | Default {: style="width:10%"} | Notes |
+|---|---|---|---|
+| `plugNPiN.adguardHomeOptions.targetDomain` | If provided, a CNAME DNS Rewrite will be created | | |
 
 ### Nginx Proxy Manager
 
@@ -56,8 +62,8 @@ Use the following labels on your containers to enable specific features
 
 ### Pi-Hole
 
-| Label {: style="width:35%"} | Description | Default {: style="width:10%"} |
-|---|---|---|
-| `plugNPiN.piholeOptions.targetDomain` | If provided, a CNAME record will be created **instead** of a DNS record |  |
+| Label {: style="width:35%"} | Description | Default {: style="width:10%"} | Notes |
+|---|---|---|---|
+| `plugNPiN.piholeOptions.targetDomain` | If provided, a CNAME record will be created **instead** of a DNS record | | |
 
 *[NPM]: Nginx Proxy Manager

--- a/e2e_tests/e2e_test.go
+++ b/e2e_tests/e2e_test.go
@@ -50,7 +50,71 @@ const (
 	testContainerName  = "plugnpin-e2e-test-testcontainer"
 )
 
-var logger = logging.GetLogger()
+var (
+	logger                 = logging.GetLogger()
+	globalImagesToRemove   = make(map[string]struct{})
+	globalImagesToRemoveMu sync.Mutex
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	ctx := context.Background()
+	dockerCli, err := dockerApi.NewClientWithOpts(dockerApi.FromEnv)
+	if err == nil {
+		logger.Info("Performing global image cleanup")
+		for image := range globalImagesToRemove {
+			dockerCli.ImageRemove(ctx, image, imageApi.RemoveOptions{
+				Force: true,
+			})
+		}
+	}
+
+	os.Exit(code)
+}
+
+func getInfraContainers(conf *config, workingDir string) []Container {
+	return []Container{
+		{
+			image: fmt.Sprintf("%s:%s", npmImage, conf.NpmTag),
+			name:  npmContainerName,
+			hostConfig: &containerApi.HostConfig{
+				Binds: []string{
+					fmt.Sprintf("%s/npm-data/data:/data", workingDir),
+					fmt.Sprintf("%s/npm-data/letsencrypt:/etc/letsencrypt", workingDir),
+				},
+				PortBindings: nat.PortMap{
+					nat.Port("81/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
+				},
+			},
+			exposedPort: nat.Port("81/tcp"),
+		},
+		{
+			env:   []string{`FTLCONF_webserver_api_password=password`},
+			image: fmt.Sprintf("%s:%s", piholeImage, conf.PiholeTag),
+			name:  piholeContainerName,
+			hostConfig: &containerApi.HostConfig{
+				PortBindings: nat.PortMap{
+					nat.Port("80/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
+				},
+			},
+			exposedPort: nat.Port("80/tcp"),
+		},
+		{
+			image: fmt.Sprintf("%s:%s", adguardHomeImage, conf.AdguardHomeTag),
+			name:  adguardHomeContainerName,
+			hostConfig: &containerApi.HostConfig{
+				PortBindings: nat.PortMap{
+					nat.Port("3000/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
+				},
+				Binds: []string{
+					fmt.Sprintf("%s/adguardhome-data/conf:/opt/adguardhome/conf", workingDir),
+				},
+			},
+			exposedPort: nat.Port("3000/tcp"),
+		},
+	}
+}
 
 func getEnvVars() (*config, error) {
 	err := godotenv.Load(".env.test")
@@ -73,12 +137,17 @@ func pullRequiredImages(t *testing.T, ctx context.Context, dockerApi *dockerApi.
 			if err != nil {
 				return fmt.Errorf("failed to pull image %s: %w", containers[i].image, err)
 			}
+
+			globalImagesToRemoveMu.Lock()
+			globalImagesToRemove[containers[i].image] = struct{}{}
+			globalImagesToRemoveMu.Unlock()
+
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		cleanup(t, ctx, dockerApi, containers, nil)
+		cleanup(t, dockerApi, containers, nil)
 		t.Fatal(err)
 	}
 }
@@ -91,6 +160,7 @@ func startRequiredContainers(t *testing.T, ctx context.Context, dockerCli *docke
 			cfg := &containerApi.Config{
 				Cmd:          containers[i].cmd,
 				Env:          containers[i].env,
+				Healthcheck:  containers[i].healthcheck,
 				Image:        containers[i].image,
 				Labels:       containers[i].labels,
 				ExposedPorts: make(nat.PortSet),
@@ -117,16 +187,17 @@ func startRequiredContainers(t *testing.T, ctx context.Context, dockerCli *docke
 			}
 			containers[i].id = response.ID
 			logger.Info("container started", "name", containers[i].name, "id", containers[i].id)
-			err = dockerCli.ContainerStart(ctx, containers[i].id, containerApi.StartOptions{})
+			err = dockerCli.ContainerStart(gCtx, containers[i].id, containerApi.StartOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to start container %s: %v", containers[i].name, err)
 			}
 
 			if containers[i].exposedPort != "" {
-				containerInfo, err := dockerCli.ContainerInspect(ctx, containers[i].id)
+				containerInfo, err := dockerCli.ContainerInspect(gCtx, containers[i].id)
 				if err != nil {
 					return fmt.Errorf("failed to inspect container %s: %v", containers[i].name, err)
 				}
+
 				bindings := containerInfo.NetworkSettings.Ports[containers[i].exposedPort]
 				if len(bindings) > 0 {
 					hostPort := bindings[0].HostPort
@@ -138,7 +209,7 @@ func startRequiredContainers(t *testing.T, ctx context.Context, dockerCli *docke
 		})
 	}
 	if err := g.Wait(); err != nil {
-		cleanup(t, ctx, dockerCli, containers, nil)
+		cleanup(t, dockerCli, containers, nil)
 		t.Fatal(err)
 	}
 }
@@ -213,8 +284,11 @@ func setup(t *testing.T, ctx context.Context, dockerCli *dockerApi.Client, conta
 	return dockerClient, piholeClient, npmClient, adguardHomeClient
 }
 
-func cleanup(t *testing.T, ctx context.Context, dockerCli *dockerApi.Client, containers []Container, npmClient *npm.Client) {
+func cleanup(t *testing.T, dockerCli *dockerApi.Client, containers []Container, npmClient *npm.Client) {
 	logger.Info("In cleanup")
+
+	// Use background context for cleanup to ensure it completes even if test is canceled
+	ctx := context.Background()
 
 	if npmClient != nil {
 		npmProxyHosts, err := npmClient.GetProxyHosts()
@@ -222,10 +296,8 @@ func cleanup(t *testing.T, ctx context.Context, dockerCli *dockerApi.Client, con
 			npmClient.DeleteProxyHosts(slices.Collect(maps.Keys(npmProxyHosts)))
 		}
 	}
-	imagesToRemove := make(map[string]struct{})
 	var wg sync.WaitGroup
 	for i := range containers {
-		imagesToRemove[containers[i].image] = struct{}{}
 		wg.Go(func() {
 			if containers[i].id == "" {
 				return
@@ -239,15 +311,6 @@ func cleanup(t *testing.T, ctx context.Context, dockerCli *dockerApi.Client, con
 		})
 	}
 	wg.Wait()
-
-	for image := range imagesToRemove {
-		_, err := dockerCli.ImageRemove(ctx, image, imageApi.RemoveOptions{
-			Force: true,
-		})
-		if err != nil {
-			logger.Error("Could not remove image", "image", image, "error", err)
-		}
-	}
 }
 
 func TestE2E(t *testing.T) {
@@ -269,45 +332,8 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
 
-	containers := []Container{
-		{
-			image: fmt.Sprintf("%s:%s", npmImage, conf.NpmTag),
-			name:  npmContainerName,
-			hostConfig: &containerApi.HostConfig{
-				Binds: []string{
-					fmt.Sprintf("%s/npm-data/data:/data", workingDir),
-					fmt.Sprintf("%s/npm-data/letsencrypt:/etc/letsencrypt", workingDir),
-				},
-				PortBindings: nat.PortMap{
-					nat.Port("81/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
-				},
-			},
-			exposedPort: nat.Port("81/tcp"),
-		},
-		{
-			env:   []string{`FTLCONF_webserver_api_password=password`},
-			image: fmt.Sprintf("%s:%s", piholeImage, conf.PiholeTag),
-			name:  piholeContainerName,
-			hostConfig: &containerApi.HostConfig{
-				PortBindings: nat.PortMap{
-					nat.Port("80/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
-				},
-			},
-			exposedPort: nat.Port("80/tcp"),
-		},
-		{
-			image: fmt.Sprintf("%s:%s", adguardHomeImage, conf.AdguardHomeTag),
-			name:  adguardHomeContainerName,
-			hostConfig: &containerApi.HostConfig{
-				PortBindings: nat.PortMap{
-					nat.Port("3000/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}},
-				},
-				Binds: []string{
-					fmt.Sprintf("%s/adguardhome-data/conf:/opt/adguardhome/conf", workingDir),
-				},
-			},
-			exposedPort: nat.Port("3000/tcp"),
-		},
+	infraContainers := getInfraContainers(conf, workingDir)
+	testContainers := []Container{
 		{
 			image: testContainerImage,
 			cmd:   []string{"tail", "-f", "/dev/null"},
@@ -329,11 +355,12 @@ func TestE2E(t *testing.T) {
 			hostConfig: &containerApi.HostConfig{},
 		},
 	}
+	containers := append(infraContainers, testContainers...)
 
 	dockerClient, piholeClient, npmClient, adguardHomeClient := setup(t, ctx, dockerCli, containers)
 
 	t.Cleanup(func() {
-		cleanup(t, ctx, dockerCli, containers, npmClient)
+		cleanup(t, dockerCli, containers, npmClient)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -406,4 +433,196 @@ func TestE2E(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestE2E_CreateOnHealthy(t *testing.T) {
+	logger.Info("In TestE2E_CreateOnHealthy")
+
+	conf, err := getEnvVars()
+	if err != nil {
+		t.Fatalf("Failed to load e2e test env vars: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dockerCli, err := dockerApi.NewClientWithOpts(dockerApi.FromEnv)
+	if err != nil {
+		t.Fatalf("Failed to create docker api client: %v", err)
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	infraContainers := getInfraContainers(conf, workingDir)
+
+	dockerClient, piholeClient, npmClient, adguardHomeClient := setup(t, ctx, dockerCli, infraContainers)
+
+	t.Cleanup(func() {
+		cleanup(t, dockerCli, infraContainers, npmClient)
+	})
+
+	proc := processor.New(
+		map[string]*docker.Client{dockerClient.Host: dockerClient},
+		adguardHomeClient,
+		piholeClient,
+		npmClient,
+		false,
+	)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		proc.ListenForEvents(ctx)
+	})
+
+	testURL := "healthy-test.home"
+	testContainers := []Container{
+		{
+			image: testContainerImage,
+			cmd:   []string{"tail", "-f", "/dev/null"},
+			labels: map[string]string{
+				docker.IpLabel:  "3.3.3.3:8080",
+				docker.UrlLabel: testURL,
+				docker.GeneralOptionsCreateOnHealthyLabel: "true",
+			},
+			name:       testContainerName + "-healthy-trigger",
+			hostConfig: &containerApi.HostConfig{},
+			healthcheck: &containerApi.HealthConfig{
+				Test:     []string{"CMD-SHELL", "stat /tmp/healthy || exit 1"},
+				Interval: 1 * time.Second,
+				Retries:  30,
+			},
+		},
+	}
+
+	pullImage(ctx, dockerCli, testContainers[0].image)
+	startRequiredContainers(t, ctx, dockerCli, testContainers)
+
+	t.Cleanup(func() {
+		dockerCli.ContainerRemove(context.Background(), testContainers[0].id, containerApi.RemoveOptions{Force: true})
+	})
+
+	// Assert entry DOES NOT exist while unhealthy
+	logger.Info("Asserting entry does not exist while container is unhealthy")
+	require.Never(t, func() bool {
+		npmProxyHosts, _ := npmClient.GetProxyHosts()
+		_, exists := npmProxyHosts[testURL]
+		return exists
+	}, 3*time.Second, 1*time.Second, "Entry should not be created for unhealthy container")
+
+	// Trigger healthy state
+	logger.Info("Triggering healthy state")
+	err = markContainerHealthy(ctx, dockerCli, testContainers[0].id)
+	require.NoError(t, err)
+
+	// Wait for Docker to mark it healthy
+	logger.Info("Waiting for Docker to mark container as healthy")
+	require.Eventually(t, func() bool {
+		inspect, err := dockerCli.ContainerInspect(ctx, testContainers[0].id)
+		if err != nil {
+			return false
+		}
+		return inspect.State.Health != nil && inspect.State.Health.Status == "healthy"
+	}, 15*time.Second, 1*time.Second, "Container should become healthy")
+
+	// Assert entry exists
+	logger.Info("Asserting entry now exists after container became healthy")
+	require.Eventually(t, func() bool {
+		npmProxyHosts, _ := npmClient.GetProxyHosts()
+		_, exists := npmProxyHosts[testURL]
+		return exists
+	}, 10*time.Second, 1*time.Second, "Entry should be created after container becomes healthy")
+
+	// Assert entry is REMOVED on Die
+	logger.Info("Stopping container and asserting entry removal")
+	err = dockerCli.ContainerStop(ctx, testContainers[0].id, containerApi.StopOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		npmProxyHosts, _ := npmClient.GetProxyHosts()
+		_, exists := npmProxyHosts[testURL]
+		return !exists
+	}, 10*time.Second, 1*time.Second, "Entry should be removed after container dies")
+
+	cancel()
+	wg.Wait()
+}
+
+func TestE2E_CreateOnHealthy_NoHealthcheck(t *testing.T) {
+	logger.Info("In TestE2E_CreateOnHealthy_NoHealthcheck")
+
+	conf, err := getEnvVars()
+	if err != nil {
+		t.Fatalf("Failed to load e2e test env vars: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dockerCli, err := dockerApi.NewClientWithOpts(dockerApi.FromEnv)
+	if err != nil {
+		t.Fatalf("Failed to create docker api client: %v", err)
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	infraContainers := getInfraContainers(conf, workingDir)
+
+	dockerClient, _, npmClient, adguardHomeClient := setup(t, ctx, dockerCli, infraContainers)
+
+	t.Cleanup(func() {
+		cleanup(t, dockerCli, infraContainers, npmClient)
+	})
+
+	proc := processor.New(
+		map[string]*docker.Client{dockerClient.Host: dockerClient},
+		adguardHomeClient,
+		nil,
+		npmClient,
+		false,
+	)
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		proc.ListenForEvents(ctx)
+	})
+
+	testURL := "no-healthcheck-test.home"
+	testContainers := []Container{
+		{
+			image: testContainerImage,
+			cmd:   []string{"tail", "-f", "/dev/null"},
+			labels: map[string]string{
+				docker.IpLabel:  "4.4.4.4:8080",
+				docker.UrlLabel: testURL,
+				docker.GeneralOptionsCreateOnHealthyLabel: "true",
+			},
+			name:       testContainerName + "-no-healthcheck",
+			hostConfig: &containerApi.HostConfig{},
+			// NO healthcheck defined
+		},
+	}
+
+	pullImage(ctx, dockerCli, testContainers[0].image)
+	startRequiredContainers(t, ctx, dockerCli, testContainers)
+
+	t.Cleanup(func() {
+		dockerCli.ContainerRemove(context.Background(), testContainers[0].id, containerApi.RemoveOptions{Force: true})
+	})
+
+	// Assert entry NEVER exists
+	logger.Info("Asserting entry is NOT created for container without healthcheck")
+	require.Never(t, func() bool {
+		npmProxyHosts, _ := npmClient.GetProxyHosts()
+		_, exists := npmProxyHosts[testURL]
+		return exists
+	}, 5*time.Second, 1*time.Second, "Entry should NOT be created when no healthcheck is defined")
+
+	cancel()
+	wg.Wait()
 }

--- a/e2e_tests/e2e_test.go
+++ b/e2e_tests/e2e_test.go
@@ -497,7 +497,8 @@ func TestE2E_CreateOnHealthy(t *testing.T) {
 		},
 	}
 
-	pullImage(ctx, dockerCli, testContainers[0].image)
+	err = pullImage(ctx, dockerCli, testContainers[0].image)
+	require.NoError(t, err, "Failed to pull test container image")
 	startRequiredContainers(t, ctx, dockerCli, testContainers)
 
 	t.Cleanup(func() {
@@ -608,7 +609,8 @@ func TestE2E_CreateOnHealthy_NoHealthcheck(t *testing.T) {
 		},
 	}
 
-	pullImage(ctx, dockerCli, testContainers[0].image)
+	err = pullImage(ctx, dockerCli, testContainers[0].image)
+	require.NoError(t, err, "Failed to pull test container image")
 	startRequiredContainers(t, ctx, dockerCli, testContainers)
 
 	t.Cleanup(func() {

--- a/e2e_tests/e2e_test.go
+++ b/e2e_tests/e2e_test.go
@@ -373,7 +373,7 @@ func TestE2E(t *testing.T) {
 		false,
 	)
 
-	proc.RunOnce()
+	proc.RunOnce(ctx)
 
 	piholeDnsRecords, err := piholeClient.GetDnsRecords()
 	if err != nil {

--- a/e2e_tests/types.go
+++ b/e2e_tests/types.go
@@ -11,6 +11,7 @@ type Container struct {
 	cmd         []string
 	env         []string
 	exposedPort nat.Port
+	healthcheck *containerApi.HealthConfig
 	hostConfig  *containerApi.HostConfig
 	id          string
 	image       string

--- a/e2e_tests/utils.go
+++ b/e2e_tests/utils.go
@@ -4,8 +4,10 @@ package e2e_tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 
+	containerApi "github.com/docker/docker/api/types/container"
 	imageApi "github.com/docker/docker/api/types/image"
 	dockerCliClient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -24,5 +26,23 @@ func pullImage(ctx context.Context, dockerCli *dockerCliClient.Client, img strin
 	defer reader.Close()
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
 	jsonmessage.DisplayJSONMessagesStream(reader, os.Stderr, termFd, isTerm, nil)
+	return nil
+}
+
+func markContainerHealthy(ctx context.Context, dockerCli *dockerCliClient.Client, containerID string) error {
+	execConfig := containerApi.ExecOptions{
+		Cmd: []string{"touch", "/tmp/healthy"},
+	}
+
+	execCreateResp, err := dockerCli.ContainerExecCreate(ctx, containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec: %w", err)
+	}
+
+	err = dockerCli.ContainerExecStart(ctx, execCreateResp.ID, containerApi.ExecStartOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to start exec: %w", err)
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ import (
 var log = logging.GetLogger()
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	cliFlags := cli.ParseFlags()
 
 	conf, err := config.GetEnvVars()
@@ -45,36 +48,22 @@ func main() {
 
 	if conf.RunInterval == 0 {
 		log.Info("RUN_INTERVAL is 0, will run once")
-		proc.RunOnce()
+		proc.RunOnce(ctx)
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		proc.ListenForEvents(ctx)
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		proc.RunScheduled(ctx, conf.RunInterval)
-	}()
+	})
 
-	shutdown(cancel, &wg)
-}
-
-func shutdown(cancelCtx context.CancelFunc, wg *sync.WaitGroup) {
-	shutdownChan := make(chan os.Signal, 1)
-	signal.Notify(shutdownChan, syscall.SIGINT, syscall.SIGTERM)
-
-	<-shutdownChan
-
+	<-ctx.Done()
 	log.Info("Shutdown signal received, exiting gracefully.")
-	cancelCtx()
 	wg.Wait()
 	log.Info("Shutdown complete.")
 }

--- a/pkg/clients/docker/docker.go
+++ b/pkg/clients/docker/docker.go
@@ -19,16 +19,22 @@ import (
 )
 
 type ClientOptions struct {
-	AdguardHome *adguardhome.AdguardHomeOptions
-	Pihole      *pihole.PiHoleOptions
-	NPM         *npm.NpmProxyHostOptions
+	AdguardHome    *adguardhome.AdguardHomeOptions
+	GeneralOptions GeneralOptions
+	NPM            *npm.NpmProxyHostOptions
+	Pihole         *pihole.PiHoleOptions
+}
+
+type GeneralOptions struct {
+	CreateOnHealthy bool
 }
 
 var log = logging.GetLogger()
 
 const (
-	IpLabel  = "plugNPiN.ip"
-	UrlLabel = "plugNPiN.url"
+	GeneralOptionsCreateOnHealthyLabel = "plugNPiN.options.createOnHealthy"
+	IpLabel                            = "plugNPiN.ip"
+	UrlLabel                           = "plugNPiN.url"
 
 	adguardHomeOptionsTargetDomainLabel = "plugNPiN.adguardHomeOptions.targetDomain"
 	npmOptionsAccessListNameLabel       = "plugNPiN.npmOptions.accessListName"
@@ -104,6 +110,9 @@ func GetValuesFromLabels(labels map[string]string) (ip string, urls []string, po
 
 	opts = &ClientOptions{}
 
+	generalOptionsCreateOnHealthy, _ := strconv.ParseBool(labels[GeneralOptionsCreateOnHealthyLabel])
+	opts.GeneralOptions = GeneralOptions{CreateOnHealthy: generalOptionsCreateOnHealthy}
+
 	npmOptionsBlockExploitsLabelValue, exists := labels[npmOptionsBlockExploitsLabel]
 	if !exists {
 		npmOptionsBlockExploitsLabelValue = "true"
@@ -159,4 +168,16 @@ func GetValuesFromLabels(labels map[string]string) (ip string, urls []string, po
 	}
 
 	return ip, urls, port, opts, nil
+}
+
+func (d *Client) InspectContainer(ctx context.Context, containerID string) (container.InspectResponse, error) {
+	return d.ContainerInspect(ctx, containerID)
+}
+
+func (d *Client) HasHealthcheck(containerInspectResponse container.InspectResponse) bool {
+	return containerInspectResponse.Config.Healthcheck != nil && len(containerInspectResponse.Config.Healthcheck.Test) > 0
+}
+
+func (d *Client) IsHealthy(containerInspectResponse container.InspectResponse) bool {
+	return containerInspectResponse.State.Health != nil && containerInspectResponse.State.Health.Status == CONTAINER_HEALTHY_STATUS
 }

--- a/pkg/clients/docker/docker.go
+++ b/pkg/clients/docker/docker.go
@@ -175,9 +175,13 @@ func (d *Client) InspectContainer(ctx context.Context, containerID string) (cont
 }
 
 func (d *Client) HasHealthcheck(containerInspectResponse container.InspectResponse) bool {
-	return containerInspectResponse.Config.Healthcheck != nil && len(containerInspectResponse.Config.Healthcheck.Test) > 0
+	return containerInspectResponse.Config != nil &&
+		containerInspectResponse.Config.Healthcheck != nil &&
+		len(containerInspectResponse.Config.Healthcheck.Test) > 0
 }
 
 func (d *Client) IsHealthy(containerInspectResponse container.InspectResponse) bool {
-	return containerInspectResponse.State.Health != nil && containerInspectResponse.State.Health.Status == CONTAINER_HEALTHY_STATUS
+	return containerInspectResponse.State != nil &&
+		containerInspectResponse.State.Health != nil &&
+		containerInspectResponse.State.Health.Status == CONTAINER_HEALTHY_STATUS
 }

--- a/pkg/clients/docker/docker.go
+++ b/pkg/clients/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -170,8 +171,15 @@ func GetValuesFromLabels(labels map[string]string) (ip string, urls []string, po
 	return ip, urls, port, opts, nil
 }
 
-func (d *Client) InspectContainer(ctx context.Context, containerID string) (container.InspectResponse, error) {
-	return d.ContainerInspect(ctx, containerID)
+func (d *Client) InspectContainer(ctx context.Context, containerId string) (container.InspectResponse, error) {
+	// If the incoming context doesn't already have a deadline,
+	// enforce a 5-second safety bound for this specific Docker call.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+	return d.ContainerInspect(ctx, containerId)
 }
 
 func (d *Client) HasHealthcheck(containerInspectResponse container.InspectResponse) bool {

--- a/pkg/clients/docker/docker_test.go
+++ b/pkg/clients/docker/docker_test.go
@@ -74,6 +74,7 @@ func TestGetValuesFromContainerLabels(t *testing.T) {
 		expectedNpmOptionsScheme               string
 		expectedNpmOptionsWebsocketsSupport    bool
 		expectedPiholeOptionsTargetDomain      string
+		expectedCreateOnHealthy                bool
 	}{
 		{
 			name: "Happy path",
@@ -291,12 +292,46 @@ func TestGetValuesFromContainerLabels(t *testing.T) {
 				},
 			},
 			expectedIP:                             "192.168.1.10",
-			expectedURLs:                            []string{"my-service.example.com"},
+			expectedURLs:                           []string{"my-service.example.com"},
 			expectedPort:                           8080,
 			expectedErr:                            nil,
 			expectedNpmOptionsScheme:               "http",
 			expectedNpmOptionsBlockExploits:        true,
 			expectedAdguardHomeOptionsTargetDomain: "custom.domain.adguard",
+		},
+		{
+			name: "General options - CreateOnHealthy true",
+			container: container.Summary{
+				Labels: map[string]string{
+					IpLabel:                            "192.168.1.10:8080",
+					UrlLabel:                           "my-service.example.com",
+					GeneralOptionsCreateOnHealthyLabel: "true",
+				},
+			},
+			expectedIP:                      "192.168.1.10",
+			expectedURLs:                    []string{"my-service.example.com"},
+			expectedPort:                    8080,
+			expectedErr:                     nil,
+			expectedNpmOptionsScheme:        "http",
+			expectedNpmOptionsBlockExploits: true,
+			expectedCreateOnHealthy:         true,
+		},
+		{
+			name: "General options - CreateOnHealthy false",
+			container: container.Summary{
+				Labels: map[string]string{
+					IpLabel:                            "192.168.1.10:8080",
+					UrlLabel:                           "my-service.example.com",
+					GeneralOptionsCreateOnHealthyLabel: "false",
+				},
+			},
+			expectedIP:                      "192.168.1.10",
+			expectedURLs:                    []string{"my-service.example.com"},
+			expectedPort:                    8080,
+			expectedErr:                     nil,
+			expectedNpmOptionsScheme:        "http",
+			expectedNpmOptionsBlockExploits: true,
+			expectedCreateOnHealthy:         false,
 		},
 	}
 
@@ -313,12 +348,14 @@ func TestGetValuesFromContainerLabels(t *testing.T) {
 				assert.NotNil(t, opts.NPM)
 				assert.NotNil(t, opts.Pihole)
 				assert.NotNil(t, opts.AdguardHome)
+				assert.NotNil(t, opts.GeneralOptions)
 				assert.Equal(t, tc.expectedNpmOptionsBlockExploits, opts.NPM.BlockExploits)
 				assert.Equal(t, tc.expectedNpmOptionsCachingEnabled, opts.NPM.CachingEnabled)
 				assert.Equal(t, tc.expectedNpmOptionsScheme, opts.NPM.ForwardScheme)
 				assert.Equal(t, tc.expectedNpmOptionsWebsocketsSupport, opts.NPM.AllowWebsocketUpgrade)
 				assert.Equal(t, tc.expectedPiholeOptionsTargetDomain, opts.Pihole.TargetDomain)
 				assert.Equal(t, tc.expectedAdguardHomeOptionsTargetDomain, opts.AdguardHome.TargetDomain)
+				assert.Equal(t, tc.expectedCreateOnHealthy, opts.GeneralOptions.CreateOnHealthy)
 			} else {
 				assert.Nil(t, opts)
 			}

--- a/pkg/clients/docker/events.go
+++ b/pkg/clients/docker/events.go
@@ -9,9 +9,10 @@ import (
 
 func Listen(ctx context.Context, dockerClient *Client, handler func(events.Message)) error {
 	f := filters.NewArgs()
-	f.Add("type", "container")
-	f.Add("event", ContainerEvent.Start.String())
-	f.Add("event", ContainerEvent.Die.String())
+	f.Add("type", string(events.ContainerEventType))
+	f.Add("event", string(events.ActionDie))
+	f.Add("event", string(events.ActionHealthStatusHealthy))
+	f.Add("event", string(events.ActionStart))
 
 	log.Info("Listening for Docker events...", "host", dockerClient.DisplayHost)
 

--- a/pkg/clients/docker/types.go
+++ b/pkg/clients/docker/types.go
@@ -3,36 +3,11 @@ package docker
 import dockerSdk "github.com/docker/go-sdk/client"
 
 const (
-	start = "start"
-	die   = "die"
+	CONTAINER_HEALTHY_STATUS = "healthy"
 )
 
 type Client struct {
 	*dockerSdk.Client
 	DisplayHost string
 	Host        string
-}
-
-type EventType string
-
-type ContainerEventEnum struct {
-	Start EventType
-	Die   EventType
-}
-
-var ContainerEvent = ContainerEventEnum{
-	Start: start,
-	Die:   die,
-}
-
-func (et EventType) String() string {
-	return string(et)
-}
-
-func (ce ContainerEventEnum) ParseString(s string) (EventType, bool) {
-	event, ok := map[string]EventType{
-		start: ce.Start,
-		die:   ce.Die,
-	}[s]
-	return event, ok
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -37,7 +37,7 @@ func New(dockerClients map[string]*docker.Client, adguardHomeClient *adguardhome
 }
 
 func (p *Processor) RunScheduled(ctx context.Context, interval time.Duration) {
-	p.RunOnce()
+	p.RunOnce(ctx)
 
 	if interval == 0 {
 		return
@@ -51,7 +51,7 @@ func (p *Processor) RunScheduled(ctx context.Context, interval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			p.RunOnce()
+			p.RunOnce(ctx)
 			log.Info(fmt.Sprintf("Will run again in %v. Press Ctrl+C to exit.", interval))
 		case <-ctx.Done():
 			return
@@ -64,7 +64,7 @@ func (p *Processor) ListenForEvents(ctx context.Context) {
 		go func(client *docker.Client) {
 			log.Info("Starting event listener", "host", client.DisplayHost)
 			err := docker.Listen(ctx, client, func(event events.Message) {
-				p.handleDockerEvent(event, client)
+				p.handleDockerEvent(ctx, event, client)
 			})
 			if err != nil && err != context.Canceled {
 				log.Error("Docker event listener stopped", "host", client.DisplayHost, "error", err)
@@ -73,7 +73,7 @@ func (p *Processor) ListenForEvents(ctx context.Context) {
 	}
 }
 
-func (p *Processor) RunOnce() {
+func (p *Processor) RunOnce(ctx context.Context) {
 	for _, dockerClient := range p.dockerClients {
 		containers, err := dockerClient.GetRelevantContainers()
 		if err != nil {
@@ -84,13 +84,13 @@ func (p *Processor) RunOnce() {
 		log.Info(fmt.Sprintf("Found %v containers", len(containers)), "host", dockerClient.DisplayHost)
 
 		for _, container := range containers {
-			p.preprocessContainer(container, dockerClient)
+			p.preprocessContainer(ctx, container, dockerClient)
 		}
 	}
 	log.Info("Done")
 }
 
-func (p *Processor) preprocessContainer(container container.Summary, dockerClient *docker.Client) {
+func (p *Processor) preprocessContainer(ctx context.Context, container container.Summary, dockerClient *docker.Client) {
 	parsedContainerName := docker.GetParsedContainerName(container)
 
 	ip, urls, port, opts, err := docker.GetValuesFromLabels(container.Labels)
@@ -103,10 +103,10 @@ func (p *Processor) preprocessContainer(container container.Summary, dockerClien
 		}
 		return
 	}
-	p.processContainer(context.Background(), events.ActionStart, container.ID, dockerClient, parsedContainerName, ip, urls, port, opts)
+	p.processContainer(ctx, events.ActionStart, container.ID, dockerClient, parsedContainerName, ip, urls, port, opts)
 }
 
-func (p *Processor) handleDockerEvent(event events.Message, dockerClient *docker.Client) {
+func (p *Processor) handleDockerEvent(ctx context.Context, event events.Message, dockerClient *docker.Client) {
 	containerName, ok := event.Actor.Attributes["name"]
 	if !ok {
 		log.Info(fmt.Sprintf("Skipping event for container with no name: %v", event.Actor.ID), "host", dockerClient.DisplayHost)
@@ -124,7 +124,7 @@ func (p *Processor) handleDockerEvent(event events.Message, dockerClient *docker
 		}
 		return
 	}
-	p.processContainer(context.Background(), event.Action, event.Actor.ID, dockerClient, containerName, ip, urls, port, opts)
+	p.processContainer(ctx, event.Action, event.Actor.ID, dockerClient, containerName, ip, urls, port, opts)
 }
 
 func (p *Processor) shouldSkip(generalOptions *docker.GeneralOptions, event events.Action) bool {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -61,13 +61,13 @@ func (p *Processor) RunScheduled(ctx context.Context, interval time.Duration) {
 
 func (p *Processor) ListenForEvents(ctx context.Context) {
 	for _, client := range p.dockerClients {
-		go func(c *docker.Client) {
-			log.Info("Starting event listener", "host", c.DisplayHost)
-			err := docker.Listen(ctx, c, func(event events.Message) {
-				p.handleDockerEvent(event, c.DisplayHost)
+		go func(client *docker.Client) {
+			log.Info("Starting event listener", "host", client.DisplayHost)
+			err := docker.Listen(ctx, client, func(event events.Message) {
+				p.handleDockerEvent(event, client)
 			})
 			if err != nil && err != context.Canceled {
-				log.Error("Docker event listener stopped", "host", c.DisplayHost, "error", err)
+				log.Error("Docker event listener stopped", "host", client.DisplayHost, "error", err)
 			}
 		}(client)
 	}
@@ -84,13 +84,13 @@ func (p *Processor) RunOnce() {
 		log.Info(fmt.Sprintf("Found %v containers", len(containers)), "host", dockerClient.DisplayHost)
 
 		for _, container := range containers {
-			p.preprocessContainer(container, dockerClient.DisplayHost)
+			p.preprocessContainer(container, dockerClient)
 		}
 	}
 	log.Info("Done")
 }
 
-func (p *Processor) preprocessContainer(container container.Summary, host string) {
+func (p *Processor) preprocessContainer(container container.Summary, dockerClient *docker.Client) {
 	parsedContainerName := docker.GetParsedContainerName(container)
 
 	ip, urls, port, opts, err := docker.GetValuesFromLabels(container.Labels)
@@ -103,13 +103,13 @@ func (p *Processor) preprocessContainer(container container.Summary, host string
 		}
 		return
 	}
-	p.processContainer(docker.ContainerEvent.Start, host, parsedContainerName, ip, urls, port, opts)
+	p.processContainer(context.Background(), events.ActionStart, container.ID, dockerClient, parsedContainerName, ip, urls, port, opts)
 }
 
-func (p *Processor) handleDockerEvent(event events.Message, host string) {
+func (p *Processor) handleDockerEvent(event events.Message, dockerClient *docker.Client) {
 	containerName, ok := event.Actor.Attributes["name"]
 	if !ok {
-		log.Info(fmt.Sprintf("Skipping event for container with no name: %v", event.Actor.ID), "host", host)
+		log.Info(fmt.Sprintf("Skipping event for container with no name: %v", event.Actor.ID), "host", dockerClient.DisplayHost)
 		return
 	}
 
@@ -120,15 +120,18 @@ func (p *Processor) handleDockerEvent(event events.Message, host string) {
 			// This is not an error, it just means the container is not relevant for us
 			return
 		case *errors.MalformedIPLabelError, *errors.InvalidSchemeError:
-			log.Error("Failed to handle event for container", "host", host, "container", containerName, "error", err)
+			log.Error("Failed to handle event for container", "host", dockerClient.DisplayHost, "container", containerName, "error", err)
 		}
 		return
 	}
-	containerEvent, _ := docker.ContainerEvent.ParseString(string(event.Action))
-	p.processContainer(containerEvent, host, containerName, ip, urls, port, opts)
+	p.processContainer(context.Background(), event.Action, event.Actor.ID, dockerClient, containerName, ip, urls, port, opts)
 }
 
-func (p *Processor) handleAdguardHome(host string, containerEvent docker.EventType, containerName string, urls []string, ip string, adguardHomeOptions adguardhome.AdguardHomeOptions) {
+func (p *Processor) shouldSkip(generalOptions *docker.GeneralOptions, event events.Action) bool {
+	return (event == events.ActionStart && generalOptions.CreateOnHealthy) || (event == events.ActionHealthStatusHealthy && !generalOptions.CreateOnHealthy)
+}
+
+func (p *Processor) handleAdguardHome(host string, containerEvent events.Action, containerName string, urls []string, ip string, adguardHomeOptions adguardhome.AdguardHomeOptions, generalOptions *docker.GeneralOptions) {
 	if p.adguardHomeClient != nil {
 		if adguardHomeOptions.TargetDomain != "" {
 			// quick "workaround" for the fact that adguard unifies "local DNS records" and "CNAME records"
@@ -136,13 +139,13 @@ func (p *Processor) handleAdguardHome(host string, containerEvent docker.EventTy
 		}
 
 		switch containerEvent {
-		case docker.ContainerEvent.Start:
+		case events.ActionStart, events.ActionHealthStatusHealthy:
 			log.Info("Adding a DNS rewrite to AdGuard Home", "host", host, "container", containerName, "domains", urls, "answer", ip)
 			err := p.adguardHomeClient.AddDnsRewrites(urls, ip)
 			if err != nil {
 				log.Error("Failed to add a DNS rewrite to AdGuard Home", "host", host, "container", containerName, "domains", urls, "answer", ip, "error", err)
 			}
-		case docker.ContainerEvent.Die:
+		case events.ActionDie:
 			log.Info("Deleting DNS rewrite from AdGuard Home", "host", host, "container", containerName, "domains", urls)
 			err := p.adguardHomeClient.DeleteDnsRewrites(urls, ip)
 			if err != nil {
@@ -152,10 +155,10 @@ func (p *Processor) handleAdguardHome(host string, containerEvent docker.EventTy
 	}
 }
 
-func (p *Processor) handlePiHole(host string, containerEvent docker.EventType, containerName string, urls []string, ip string, piholeOptions pihole.PiHoleOptions) {
+func (p *Processor) handlePiHole(host string, containerEvent events.Action, containerName string, urls []string, ip string, piholeOptions pihole.PiHoleOptions, generalOptions *docker.GeneralOptions) {
 	if p.piholeClient != nil {
 		switch containerEvent {
-		case docker.ContainerEvent.Start:
+		case events.ActionStart, events.ActionHealthStatusHealthy:
 			if piholeOptions.TargetDomain == "" {
 				log.Info("Adding local DNS records to Pi-Hole", "host", host, "container", containerName, "urls", urls, "ip", ip)
 				err := p.piholeClient.AddDnsRecords(urls, ip)
@@ -169,7 +172,7 @@ func (p *Processor) handlePiHole(host string, containerEvent docker.EventType, c
 					log.Error("Failed to add local CNAME records to Pi-Hole", "host", host, "container", containerName, "urls", urls, "targetDomain", piholeOptions.TargetDomain, "error", err)
 				}
 			}
-		case docker.ContainerEvent.Die:
+		case events.ActionDie:
 			if piholeOptions.TargetDomain == "" {
 				log.Info("Deleting local DNS records from Pi-Hole", "host", host, "container", containerName, "urls", urls)
 				err := p.piholeClient.DeleteDnsRecords(urls)
@@ -187,9 +190,9 @@ func (p *Processor) handlePiHole(host string, containerEvent docker.EventType, c
 	}
 }
 
-func (p *Processor) handleNpm(host string, containerEvent docker.EventType, containerName string, urls []string, ip string, port int, npmProxyHostOptions npm.NpmProxyHostOptions) {
+func (p *Processor) handleNpm(host string, containerEvent events.Action, containerName string, urls []string, ip string, port int, npmProxyHostOptions npm.NpmProxyHostOptions, generalOptions *docker.GeneralOptions) {
 	switch containerEvent {
-	case docker.ContainerEvent.Start:
+	case events.ActionStart, events.ActionHealthStatusHealthy:
 		npmProxyHost := npm.ProxyHost{
 			AdvancedConfig:        npmProxyHostOptions.AdvancedConfig,
 			AllowWebsocketUpgrade: npmProxyHostOptions.AllowWebsocketUpgrade,
@@ -232,7 +235,7 @@ func (p *Processor) handleNpm(host string, containerEvent docker.EventType, cont
 		if err != nil {
 			log.Error("Failed to add entry to Nginx Proxy Manager", "host", host, "container", containerName, "error", err)
 		}
-	case docker.ContainerEvent.Die:
+	case events.ActionDie:
 		log.Info("Deleting entry from Nginx Proxy Manager", "host", host, "container", containerName)
 		err := p.npmClient.DeleteProxyHosts(urls)
 		if err != nil {
@@ -241,27 +244,54 @@ func (p *Processor) handleNpm(host string, containerEvent docker.EventType, cont
 	}
 }
 
-func (p *Processor) processContainer(containerEvent docker.EventType, host, containerName, ip string, urls []string, port int, opts *docker.ClientOptions) {
+func (p *Processor) processContainer(ctx context.Context, containerEvent events.Action, containerID string, dockerClient *docker.Client, containerName, ip string, urls []string, port int, opts *docker.ClientOptions) {
+	if opts.GeneralOptions.CreateOnHealthy && (containerEvent == events.ActionStart || containerEvent == events.ActionHealthStatusHealthy) {
+		containerInspectResponse, err := dockerClient.InspectContainer(ctx, containerID)
+		if err != nil {
+			log.Error("Failed to inspect container", "host", dockerClient.DisplayHost, "container", containerName, "error", err)
+			return
+		}
+
+		if !dockerClient.HasHealthcheck(containerInspectResponse) {
+			log.Error("Container has 'createOnHealthy' enabled but NO healthcheck is defined. Entries will NOT be created.", "host", dockerClient.DisplayHost, "container", containerName)
+			return
+		}
+
+		// If we are in the initial sync (which uses synthetic Start events) but the
+		// container is already healthy, we "upgrade" the event to Healthy.
+		// This ensures shouldSkip() allows it to proceed immediately.
+		if containerEvent == events.ActionStart && dockerClient.IsHealthy(containerInspectResponse) {
+			containerEvent = events.ActionHealthStatusHealthy
+		}
+	}
+
+	if p.shouldSkip(&opts.GeneralOptions, containerEvent) {
+		if containerEvent == events.ActionStart {
+			log.Info("Container is not healthy yet. Waiting for container to be healthy before creating entries.", "host", dockerClient.DisplayHost, "container", containerName)
+		}
+		return
+	}
+
 	msg := "Handling container"
 
 	if p.dryRun {
 		msg += ". In dry run mode, not doing anything."
-		log.Info(msg, "host", host, "container", containerName, "ip", ip, "port", port, "urls", urls)
+		log.Info(msg, "host", dockerClient.DisplayHost, "container", containerName, "ip", ip, "port", port, "urls", urls)
 		return
 	}
 
-	log.Info(msg, "host", host, "container", containerName, "ip", ip, "port", port, "urls", urls)
+	log.Info(msg, "host", dockerClient.DisplayHost, "container", containerName, "ip", ip, "port", port, "urls", urls)
 
 	if p.npmClient != nil {
 		npmHost := p.npmClient.GetIP()
 		if opts.AdguardHome != nil {
-			p.handleAdguardHome(host, containerEvent, containerName, urls, npmHost, *opts.AdguardHome)
+			p.handleAdguardHome(dockerClient.DisplayHost, containerEvent, containerName, urls, npmHost, *opts.AdguardHome, &opts.GeneralOptions)
 		}
 		if opts.Pihole != nil {
-			p.handlePiHole(host, containerEvent, containerName, urls, npmHost, *opts.Pihole)
+			p.handlePiHole(dockerClient.DisplayHost, containerEvent, containerName, urls, npmHost, *opts.Pihole, &opts.GeneralOptions)
 		}
 		if opts.NPM != nil {
-			p.handleNpm(host, containerEvent, containerName, urls, ip, port, *opts.NPM)
+			p.handleNpm(dockerClient.DisplayHost, containerEvent, containerName, urls, ip, port, *opts.NPM, &opts.GeneralOptions)
 		}
 	}
 }

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1,0 +1,67 @@
+//go:build unit
+
+package processor
+
+import (
+	"testing"
+
+	"github.com/deepspace2/plugnpin/pkg/clients/docker"
+	"github.com/docker/docker/api/types/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldSkip(t *testing.T) {
+	p := &Processor{}
+
+	testCases := []struct {
+		name            string
+		createOnHealthy bool
+		event           events.Action
+		expected        bool
+	}{
+		{
+			name:            "CreateOnHealthy true, event Start",
+			createOnHealthy: true,
+			event:           events.ActionStart,
+			expected:        true,
+		},
+		{
+			name:            "CreateOnHealthy true, event Healthy",
+			createOnHealthy: true,
+			event:           events.ActionHealthStatusHealthy,
+			expected:        false,
+		},
+		{
+			name:            "CreateOnHealthy false, event Start",
+			createOnHealthy: false,
+			event:           events.ActionStart,
+			expected:        false,
+		},
+		{
+			name:            "CreateOnHealthy false, event Healthy",
+			createOnHealthy: false,
+			event:           events.ActionHealthStatusHealthy,
+			expected:        true,
+		},
+		{
+			name:            "CreateOnHealthy true, event Die",
+			createOnHealthy: true,
+			event:           events.ActionDie,
+			expected:        false,
+		},
+		{
+			name:            "CreateOnHealthy false, event Die",
+			createOnHealthy: false,
+			event:           events.ActionDie,
+			expected:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := docker.GeneralOptions{CreateOnHealthy: tc.createOnHealthy}
+			actual := p.shouldSkip(&opts, tc.event)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Introduces the `plugNPiN.options.createOnHealthy` container label to delay DNS and Proxy entries creation until the container reaches a healthy state.



This ensures services are only reachable once they are fully ready. [Healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) must be defined for containers with this label. 

Containers using this label but do not have healthcheck defined will be logged as an error and skipped to preserve user intent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to create entries only after a container becomes healthy; listeners now respect container health events, improving reliability of resource creation.

* **Documentation**
  * Added "General Options" section and documented the health-based creation option, plus table formatting improvements for label docs.

* **Tests**
  * New end-to-end tests covering creation-on-healthy behavior and cases without healthchecks; added unit test for skip logic and improved cleanup reliability in test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepSpace2/PlugNPiN/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->