### PR TITLE
chore: upgrade to go 1.26.4

### DIFF
--- a/.github/workflows/reusable-unittests.yml
+++ b/.github/workflows/reusable-unittests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.4"
+          go-version: "1.26.4"
 
       - name: Run tests with coverage
         run: go test -tags=unit -coverprofile=coverage.out ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/DeepSpace2/plugnpin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deepspace2/plugnpin
 
-go 1.25.4
+go 1.26.4
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.4 across build configurations and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->