### PR TITLE
fix: close pi-hole sessions

### DIFF
--- a/e2e_tests/e2e_test.go
+++ b/e2e_tests/e2e_test.go
@@ -232,7 +232,7 @@ func setClients(t *testing.T, containers []Container) (*docker.Client, *pihole.C
 		}
 	}
 
-	piholeClient := pihole.NewClient(piholeURL)
+	piholeClient := pihole.NewClient(piholeURL, "password")
 	logger.Info("Waiting for Pi-hole to be ready...")
 	piholeLoginTimeout := time.After(60 * time.Second)
 	piholeLoginTicker := time.NewTicker(3 * time.Second)
@@ -243,7 +243,7 @@ PiholeLoginLoop:
 		case <-piholeLoginTimeout:
 			t.Fatalf("Timed out waiting for Pi-hole to be ready at %s", piholeURL)
 		case <-piholeLoginTicker.C:
-			err = piholeClient.Login("password")
+			err = piholeClient.Login()
 			if err == nil {
 				logger.Info("Successfully logged into Pi-hole")
 				break PiholeLoginLoop

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	}
 
 	proc := processor.New(dockerClients, adguardHomeClient, piholeClient, npmClient, cliFlags.DryRun)
+	defer proc.Shutdown()
 
 	if config.RunInterval == 0 {
 		log.Info("RUN_INTERVAL is 0, will run once")
@@ -78,7 +79,6 @@ func main() {
 
 	<-ctx.Done()
 	log.Info("Shutdown signal received, exiting gracefully.")
-	proc.Shutdown()
 	wg.Wait()
 	log.Info("Shutdown complete.")
 }

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 
 	<-ctx.Done()
 	log.Info("Shutdown signal received, exiting gracefully.")
+	proc.Shutdown()
 	wg.Wait()
 	log.Info("Shutdown complete.")
 }

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -19,8 +19,8 @@ func GetClients(cliFlags cli.Flags, config *config.Config) (map[string]*docker.C
 
 	if !cliFlags.DryRun {
 		if !config.PiholeDisabled {
-			piholeClient = pihole.NewClient(config.PiholeHost)
-			err := piholeClient.Login(config.PiholePassword)
+			piholeClient = pihole.NewClient(config.PiholeHost, config.PiholePassword)
+			err := piholeClient.Login()
 			if err != nil {
 				log.Error("Failed to login to Pi-Hole", "error", err)
 				return nil, nil, nil, nil, err

--- a/pkg/clients/common/common.go
+++ b/pkg/clients/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -126,16 +127,7 @@ func Patch(client *http.Client, path string, headers map[string]string, data str
 	return string(body), resp.StatusCode, nil
 }
 
-func Delete(client *http.Client, path string, headers map[string]string) (string, int, error) {
-	req, err := http.NewRequest(
-		http.MethodDelete,
-		path,
-		nil,
-	)
-	if err != nil {
-		return "", 0, err
-	}
-
+func doDeleteRequest(req *http.Request, client *http.Client, headers map[string]string) (string, int, error) {
 	setHeaders(req, headers)
 
 	resp, err := client.Do(req)
@@ -148,5 +140,33 @@ func Delete(client *http.Client, path string, headers map[string]string) (string
 	if err != nil {
 		return "", 0, err
 	}
+
 	return string(body), resp.StatusCode, nil
+}
+
+func Delete(client *http.Client, path string, headers map[string]string) (string, int, error) {
+	req, err := http.NewRequest(
+		http.MethodDelete,
+		path,
+		nil,
+	)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return doDeleteRequest(req, client, headers)
+}
+
+func DeleteWithContext(ctx context.Context, client *http.Client, path string, headers map[string]string) (string, int, error) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodDelete,
+		path,
+		nil,
+	)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return doDeleteRequest(req, client, headers)
 }

--- a/pkg/clients/pihole/errors.go
+++ b/pkg/clients/pihole/errors.go
@@ -1,0 +1,10 @@
+package pihole
+
+import (
+	"errors"
+)
+
+var (
+	errAuthRefreshFailed = errors.New("failed to refresh Pi-Hole authentication")
+	errMissingSessionId  = errors.New("missing Pi-Hole session ID")
+)

--- a/pkg/clients/pihole/pihole.go
+++ b/pkg/clients/pihole/pihole.go
@@ -1,11 +1,13 @@
 package pihole
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/deepspace2/plugnpin/pkg/clients/common"
 	"github.com/deepspace2/plugnpin/pkg/logging"
@@ -58,8 +60,11 @@ func (p *Client) Logout() error {
 	if p.sid == "" {
 		return nil
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	headers["X-FTL-SID"] = p.sid
-	_, statusCode, err := common.Delete(&p.Client, p.baseURL+"/auth", headers)
+	_, statusCode, err := common.DeleteWithContext(ctx, &p.Client, p.baseURL+"/auth", headers)
 	if err != nil {
 		return err
 	}

--- a/pkg/clients/pihole/pihole.go
+++ b/pkg/clients/pihole/pihole.go
@@ -26,18 +26,19 @@ var headers map[string]string = map[string]string{
 	"content-type": "application/json",
 }
 
-func NewClient(baseURL string) *Client {
+func NewClient(baseURL, password string) *Client {
 	return &Client{
 		Client: http.Client{
 			Transport: common.NewInstrumentedRoundTripper(metrics.PI_HOLE, metrics.ObserveApiRequestDuration),
 		},
-		baseURL: fmt.Sprintf("%v/api", baseURL),
-		sid:     "",
+		baseURL:  fmt.Sprintf("%v/api", baseURL),
+		password: password,
+		sid:      "",
 	}
 }
 
-func (p *Client) Login(password string) error {
-	loginPayload := fmt.Sprintf(`{"password": "%v"}`, password)
+func (p *Client) Login() error {
+	loginPayload := fmt.Sprintf(`{"password": "%v"}`, p.password)
 	loginResponseString, statusCode, err := common.Post(&p.Client, p.baseURL+"/auth", headers, &loginPayload)
 	if err != nil {
 		return err
@@ -49,7 +50,6 @@ func (p *Client) Login(password string) error {
 		return errors.New(resp.Session.Message)
 	}
 
-	p.password = password
 	p.sid = resp.Session.Sid
 	return nil
 }
@@ -64,7 +64,6 @@ func (p *Client) Logout() error {
 		return err
 	}
 	p.sid = ""
-	p.password = ""
 	if statusCode >= 400 {
 		log.Warn("Pi-Hole logout returned non-success status", "status", statusCode)
 	}
@@ -380,5 +379,5 @@ func (p *Client) refreshAuth() error {
 	if err := p.Logout(); err != nil {
 		log.Warn("Failed to logout old Pi-Hole session", "error", err)
 	}
-	return p.Login(p.password)
+	return p.Login()
 }

--- a/pkg/clients/pihole/pihole.go
+++ b/pkg/clients/pihole/pihole.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/deepspace2/plugnpin/pkg/clients/common"
@@ -55,6 +54,23 @@ func (p *Client) Login(password string) error {
 	return nil
 }
 
+func (p *Client) Logout() error {
+	if p.sid == "" {
+		return nil
+	}
+	headers["X-FTL-SID"] = p.sid
+	_, statusCode, err := common.Delete(&p.Client, p.baseURL+"/auth", headers)
+	if err != nil {
+		return err
+	}
+	p.sid = ""
+	p.password = ""
+	if statusCode >= 400 {
+		log.Warn("Pi-Hole logout returned non-success status", "status", statusCode)
+	}
+	return nil
+}
+
 func rawDnsRecordToRecord(rawDnsRecord string) (DomainName, IP, error) {
 	splitRawDnsRecord := strings.Split(rawDnsRecord, " ")
 	if len(splitRawDnsRecord) == 2 {
@@ -72,8 +88,7 @@ func dnsRecordToRaw(domain DomainName, ip IP) string {
 
 func (p *Client) GetDnsRecords() (DnsRecords, error) {
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return nil, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	configResponseString, _, err := common.Get(&p.Client, p.baseURL+"/config", headers)
@@ -127,8 +142,7 @@ func (p *Client) AddDnsRecords(domains []string, ip string) (numOfAddedDnsRecord
 	}
 
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return 0, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	resp, statusCode, err := common.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
@@ -137,7 +151,9 @@ func (p *Client) AddDnsRecords(domains []string, ip string) (numOfAddedDnsRecord
 	}
 
 	if statusCode == 401 {
-		p.refreshAuth()
+		if err := p.refreshAuth(); err != nil {
+			return 0, errors.Join(errAuthRefreshFailed, err)
+		}
 		return p.AddDnsRecords(domains, ip)
 	}
 
@@ -183,8 +199,7 @@ func (p *Client) DeleteDnsRecords(domains []string) (numOfDeletedDnsRecords int,
 	}
 
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return 0, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	resp, statusCode, err := common.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
@@ -193,7 +208,9 @@ func (p *Client) DeleteDnsRecords(domains []string) (numOfDeletedDnsRecords int,
 	}
 
 	if statusCode == 401 {
-		p.refreshAuth()
+		if err := p.refreshAuth(); err != nil {
+			return 0, errors.Join(errAuthRefreshFailed, err)
+		}
 		return p.DeleteDnsRecords(domains)
 	}
 
@@ -223,8 +240,7 @@ func cNameRecordToRaw(domain DomainName, target Target) string {
 
 func (p *Client) getCNameRecords() (CNameRecords, error) {
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return nil, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	configResponseString, _, err := common.Get(&p.Client, p.baseURL+"/config", headers)
@@ -278,8 +294,7 @@ func (p *Client) AddCNameRecords(domains []string, target string) (numOfAddedCNa
 	}
 
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return numOfAddedCNameRecords, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	resp, statusCode, err := common.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
@@ -288,7 +303,9 @@ func (p *Client) AddCNameRecords(domains []string, target string) (numOfAddedCNa
 	}
 
 	if statusCode == 401 {
-		p.refreshAuth()
+		if err := p.refreshAuth(); err != nil {
+			return numOfAddedCNameRecords, errors.Join(errAuthRefreshFailed, err)
+		}
 		return p.AddCNameRecords(domains, target)
 	}
 
@@ -334,8 +351,7 @@ func (p *Client) DeleteCNameRecords(domains []string) (numOfDeletedCNameRecords 
 	}
 
 	if p.sid == "" {
-		log.Error("Missing Pi-Hole session ID")
-		os.Exit(1)
+		return numOfDeletedCNameRecords, errMissingSessionId
 	}
 	headers["X-FTL-SID"] = p.sid
 	resp, statusCode, err := common.Patch(&p.Client, p.baseURL+"/config", headers, string(payloadString))
@@ -344,7 +360,9 @@ func (p *Client) DeleteCNameRecords(domains []string) (numOfDeletedCNameRecords 
 	}
 
 	if statusCode == 401 {
-		p.refreshAuth()
+		if err := p.refreshAuth(); err != nil {
+			return numOfDeletedCNameRecords, errors.Join(errAuthRefreshFailed, err)
+		}
 		return p.DeleteCNameRecords(domains)
 	}
 
@@ -357,7 +375,10 @@ func (p *Client) DeleteCNameRecords(domains []string) (numOfDeletedCNameRecords 
 	return len(deletedDomains), nil
 }
 
-func (p *Client) refreshAuth() {
+func (p *Client) refreshAuth() error {
 	log.Info("Refreshing Pi-Hole authentication")
-	p.Login(p.password)
+	if err := p.Logout(); err != nil {
+		log.Warn("Failed to logout old Pi-Hole session", "error", err)
+	}
+	return p.Login(p.password)
 }

--- a/pkg/clients/pihole/pihole_test.go
+++ b/pkg/clients/pihole/pihole_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 // setupTestServer creates a new test server and a client pointing to it.
-func setupTestServer(handler http.Handler) (*Client, *httptest.Server) {
+func setupTestServer(handler http.Handler, password string) (*Client, *httptest.Server) {
 	server := httptest.NewServer(handler)
-	client := NewClient(server.URL)
+	client := NewClient(server.URL, password)
 	client.Client = *server.Client() // Replace the default client with the test server's client
 	return client, server
 }
@@ -35,10 +35,10 @@ func TestLogin(t *testing.T) {
 			// The actual API response is more complex, so we mock the whole thing
 			fmt.Fprint(w, `{"session": {"sid": "test-sid", "message": "Login successful"}}`)
 		})
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 
-		err := client.Login("test-password")
+		err := client.Login()
 
 		assert.NoError(t, err)
 		assert.Equal(t, "test-sid", client.sid)
@@ -49,10 +49,10 @@ func TestLogin(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			fmt.Fprint(w, `{"session": {"sid": "", "message": "Invalid password"}}`)
 		})
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "wrong-password")
 		defer server.Close()
 
-		err := client.Login("wrong-password")
+		err := client.Login()
 
 		assert.Error(t, err)
 		assert.Equal(t, "Invalid password", err.Error())
@@ -71,24 +71,22 @@ func TestLogout(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprint(w, `{"session": {"sid": "", "message": "Session deleted"}}`)
 		})
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
-		client.password = "test-password"
 
 		err := client.Logout()
 
 		assert.NoError(t, err)
 		assert.True(t, deleteCalled, "DELETE /api/auth was not called")
 		assert.Empty(t, client.sid)
-		assert.Empty(t, client.password)
 	})
 
 	t.Run("no-op when already logged out", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Fatal("Unexpected request when sid is empty")
 		})
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 
 		err := client.Logout()
@@ -103,16 +101,14 @@ func TestLogout(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(w, `{}`)
 		})
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
-		client.password = "test-password"
 
 		err := client.Logout()
 
 		assert.NoError(t, err)
 		assert.Empty(t, client.sid)
-		assert.Empty(t, client.password)
 	})
 }
 
@@ -150,7 +146,7 @@ func TestAddDnsRecords(t *testing.T) {
 			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 
 		// Manually set the session ID that the login step would have provided
@@ -193,7 +189,7 @@ func TestDeleteDnsRecords(t *testing.T) {
 			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
 
@@ -217,7 +213,7 @@ func TestDeleteDnsRecords(t *testing.T) {
 			}
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
 
@@ -304,7 +300,7 @@ func TestAddCNameRecords(t *testing.T) {
 			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 
 		// Manually set the session ID that the login step would have provided
@@ -347,7 +343,7 @@ func TestDeleteCNameRecords(t *testing.T) {
 			t.Fatalf("Received unexpected request: %s %s", r.Method, r.URL.Path)
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
 
@@ -371,7 +367,7 @@ func TestDeleteCNameRecords(t *testing.T) {
 			}
 		})
 
-		client, server := setupTestServer(handler)
+		client, server := setupTestServer(handler, "test-password")
 		defer server.Close()
 		client.sid = "test-sid"
 

--- a/pkg/clients/pihole/pihole_test.go
+++ b/pkg/clients/pihole/pihole_test.go
@@ -60,6 +60,62 @@ func TestLogin(t *testing.T) {
 	})
 }
 
+func TestLogout(t *testing.T) {
+	t.Run("successful logout", func(t *testing.T) {
+		deleteCalled := false
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/auth", r.URL.Path)
+			assert.Equal(t, "DELETE", r.Method)
+			assert.Equal(t, "test-sid", r.Header.Get("X-FTL-SID"))
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"session": {"sid": "", "message": "Session deleted"}}`)
+		})
+		client, server := setupTestServer(handler)
+		defer server.Close()
+		client.sid = "test-sid"
+		client.password = "test-password"
+
+		err := client.Logout()
+
+		assert.NoError(t, err)
+		assert.True(t, deleteCalled, "DELETE /api/auth was not called")
+		assert.Empty(t, client.sid)
+		assert.Empty(t, client.password)
+	})
+
+	t.Run("no-op when already logged out", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("Unexpected request when sid is empty")
+		})
+		client, server := setupTestServer(handler)
+		defer server.Close()
+
+		err := client.Logout()
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-success status is non-fatal", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/auth", r.URL.Path)
+			assert.Equal(t, "DELETE", r.Method)
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{}`)
+		})
+		client, server := setupTestServer(handler)
+		defer server.Close()
+		client.sid = "test-sid"
+		client.password = "test-password"
+
+		err := client.Logout()
+
+		assert.NoError(t, err)
+		assert.Empty(t, client.sid)
+		assert.Empty(t, client.password)
+	})
+}
+
 func TestAddDnsRecords(t *testing.T) {
 	t.Run("successful add multiple", func(t *testing.T) {
 		// This handler needs to handle two requests in sequence

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -290,6 +290,14 @@ func (p *Processor) handleNpm(ctx context.Context, containerEvent events.Action,
 	}
 }
 
+func (p *Processor) Shutdown() {
+	if p.piholeClient != nil {
+		if err := p.piholeClient.Logout(); err != nil {
+			log.Warn("Failed to logout from Pi-Hole", "error", err)
+		}
+	}
+}
+
 func (p *Processor) processContainer(ctx context.Context, containerEvent events.Action, containerId string, dockerClient *docker.Client, containerName, ip string, urls []string, port int, opts *docker.ClientOptions) {
 	log := log.With(
 		"container", containerName,


### PR DESCRIPTION
Closes #50



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved graceful shutdown now performs a cleaner sign-out step before the app exits.

* **Bug Fixes**
  * Better handling of expired or missing Pi-hole sessions during DNS and CNAME operations.
  * Authentication refresh is now more reliable and reports failures more clearly.
  * Session data is cleared after logout, even if the server returns an error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->